### PR TITLE
fix: handle MultipleScenes delegate for rootViewController in iOS 13+

### DIFF
--- a/ios/Classes/SwiftFlutterCashfreePgSdkPlugin.swift
+++ b/ios/Classes/SwiftFlutterCashfreePgSdkPlugin.swift
@@ -50,6 +50,23 @@ public class SwiftFlutterCashfreePgSdkPlugin: NSObject, FlutterPlugin, CFRespons
         self.flutterResult = result
         self.cfPaymentGatewayService = CFPaymentGatewayService.getInstance()
         self.cfPaymentGatewayService.setCallback(self)
+
+        var rootViewController: UIViewController? = nil
+
+        if #available(iOS 13.0, *), UIApplication.shared.supportsMultipleScenes {
+            for scene in UIApplication.shared.connectedScenes {
+                if let windowScene = scene as? UIWindowScene,
+                let windowSceneDelegate = windowScene.delegate as? UIWindowSceneDelegate,
+                let window = windowSceneDelegate.window,
+                windowScene.activationState == .foregroundActive {
+                    rootViewController = window?.rootViewController
+                    break
+                }
+            }
+        } else {
+            rootViewController = UIApplication.shared.delegate?.window??.rootViewController
+        }
+
         let method = call.method
         let args = call.arguments as? Dictionary<String, Any> ?? [:]
         if method == "doNetbankingPayment" {
@@ -64,7 +81,7 @@ public class SwiftFlutterCashfreePgSdkPlugin: NSObject, FlutterPlugin, CFRespons
                     .build()
                 let systemVersion = UIDevice.current.systemVersion
                 netbankingPayment.setPlatform("iflt-e-2.1.1-3.13.3-m-s-x-i-\(systemVersion.prefix(4))")
-                if let vc = UIApplication.shared.delegate?.window??.rootViewController {
+                if let vc = rootViewController {
                     try self.cfPaymentGatewayService.doPayment(netbankingPayment, viewController: vc)
                 } else {
                     self.sendException(message: "unable to get an instance of rootViewController")
@@ -85,7 +102,7 @@ public class SwiftFlutterCashfreePgSdkPlugin: NSObject, FlutterPlugin, CFRespons
                     .build()
                 let systemVersion = UIDevice.current.systemVersion
                 upiPayment.setPlatform("iflt-e-2.1.1-3.13.3-m-s-x-i-\(systemVersion.prefix(4))")
-                if let vc = UIApplication.shared.delegate?.window??.rootViewController {
+                if let vc = rootViewController {
                     try self.cfPaymentGatewayService.doPayment(upiPayment, viewController: vc)
                 } else {
                     self.sendException(message: "unable to get an instance of rootViewController")
@@ -123,7 +140,7 @@ public class SwiftFlutterCashfreePgSdkPlugin: NSObject, FlutterPlugin, CFRespons
                     .build()
                 let systemVersion = UIDevice.current.systemVersion
                 cardPayment.setPlatform("iflt-e-2.1.1-3.13.3-m-s-x-i-\(systemVersion.prefix(4))")
-                if let vc = UIApplication.shared.delegate?.window??.rootViewController {
+                if let vc = rootViewController {
                     try self.cfPaymentGatewayService.doPayment(cardPayment, viewController: vc)
                 } else {
                     self.sendException(message: "unable to get an instance of rootViewController")
@@ -156,7 +173,7 @@ public class SwiftFlutterCashfreePgSdkPlugin: NSObject, FlutterPlugin, CFRespons
                 }
                 let systemVersion = UIDevice.current.systemVersion
                 dropCheckoutPayment.setPlatform("iflt-d-2.1.1-3.13.3-m-s-x-i-\(systemVersion.prefix(4))")
-                if let vc = UIApplication.shared.delegate?.window??.rootViewController {
+                if let vc = rootViewController {
                     try self.cfPaymentGatewayService.doPayment(dropCheckoutPayment, viewController: vc)
                 } else {
                     self.sendException(message: "unable to get an instance of rootViewController")
@@ -174,7 +191,7 @@ public class SwiftFlutterCashfreePgSdkPlugin: NSObject, FlutterPlugin, CFRespons
                                 .build()
                 let systemVersion = UIDevice.current.systemVersion
                 webCheckoutPayment.setPlatform("iflt-c-2.1.1-3.13.3-m-s-x-i-\(systemVersion.prefix(4))")
-                if let vc = UIApplication.shared.delegate?.window??.rootViewController {
+                if let vc = rootViewController {
                     try self.cfPaymentGatewayService.doPayment(webCheckoutPayment, viewController: vc)
                 } else {
                     self.sendException(message: "unable to get an instance of rootViewController")


### PR DESCRIPTION
### Overview:
This PR addresses an issue in the Flutter app where retrieving the `rootViewController` was failing in multi-scene setups on iOS 13 and later. The app experienced crashes due to the Cashfree SDK throwing an "unable to get an instance of rootViewController" error. To resolve this, support for scene delegates was added, which is necessary for handling deep links on iOS 13+ since `launchOptions` is always nil in the `AppDelegate`.

### Changes Made:
- Added support for multiple scenes by leveraging `UIApplication.shared.connectedScenes` in iOS 13+.
- Iterates through `connectedScenes` to find the active `UIWindowScene`, ensuring the `rootViewController` is accurately retrieved.
- Checks the `windowScene.activationState == .foregroundActive` to ensure the correct active window is targeted.
- Implements a fallback to the legacy `UIApplication.shared.delegate?.window??.rootViewController` method for iOS versions prior to 13.

### Why This Matters:
With iOS 13 introducing support for multiple windows (scenes), apps need to handle this when accessing the `rootViewController`. Without this fix, the app could fail to get the correct `rootViewController` in a multi-scene setup, potentially breaking navigation and user interactions.

### Testing:
- Verified on both single-window (iOS 12 and below) and multi-window environments (iOS 13+) to ensure the correct `rootViewController` is retrieved.
- Tested in various scene activation states to ensure the fix only targets active, foreground windows.

This fix ensures compatibility across iOS versions and a smoother experience for users with multiple windows on iPadOS and iOS.
